### PR TITLE
add support for modifying the cache content before sending to azure

### DIFF
--- a/project-nami-blob-cache.php
+++ b/project-nami-blob-cache.php
@@ -424,8 +424,9 @@ class PN_BlobCache {
 		//	if( substr_count( $output_buffer, $element ) < 1 )
 		//		return $output_buffer;
 		//}
-			
-		$this->cache_page_content( $output_buffer );
+
+		$filtered_output_buffer = apply_filters('pn_cached_content', $output_buffer, $this->url, $this->page_key);
+		$this->cache_page_content($filtered_output_buffer);
 		
 		$duration = round( microtime( true ) - $this->initial_timestamp, 3 );
         	


### PR DESCRIPTION
We have a WordPress setup that requires us to modify the wordpress output buffer right before sending to the browser, this is accomplished with the below `mu-plugin` and a `final_output` filter in our theme - this happens too late for the PN Blob Cache to pick up and cache the changes: 

```
ob_start();

add_action('shutdown', function () {
  $final = '';

  // We'll need to get the number of ob levels we're in, so that we can iterate over each, collecting
  // that buffer's output into the final output.
  $levels = ob_get_level();

  for ($i = 0; $i < $levels; $i++) {
    $final .= ob_get_clean();
  }

  // Apply any filters to the final output
  echo apply_filters('final_output', $final);
}, 0);
```

This PR adds support for users to modify the content that is sent to the Azure blob storage. It can be used by adding a filter on `pn_cached_content` to your theme or plugin. For example: 

```
add_filter('pn_cached_content', function ($content, $url, $key) {
  // say you wanted to add the cache URL and/or key to your HTML for debugging purposes
  $modified_content = str_replace("<head>", "<head>\n<meta name=\"CACHEURL\" content=\"{$url}\">\n<meta name=\"CACHEKEY\" content=\"{$key}\">", $content);
  
  // or you had some other modification to the final output of wordpress
  $modified_content = YourThemesContentModificationFunction($content);

  return $modified_content;
}, 1, 3);
```

We are currently running this successfully in production on a site with ~1.5M pageviews/month. 